### PR TITLE
Return LazyRenderer objects with view_cart

### DIFF
--- a/cart.py
+++ b/cart.py
@@ -114,10 +114,9 @@ class Cart(ModelSQL):
                 'untaxed_amount': currency_format(cart.sale.untaxed_amount),
             })
 
-        return current_app.response_class(
-            unicode(render_template('shopping-cart.jinja', cart=cart)),
-            headers=[('Cache-Control', 'max-age=0')]
-        )
+        response = render_template('shopping-cart.jinja', cart=cart)
+        response.headers['Cache-Control'] = 'max-age=0'
+        return response
 
     @classmethod
     def view_cart_esi(cls):
@@ -126,10 +125,9 @@ class Cart(ModelSQL):
         Similar to :meth:view_cart but for ESI
         """
         cart = cls.open_cart()
-        return current_app.response_class(
-            unicode(render_template('shopping-cart-esi.jinja', cart=cart)),
-            headers=[('Cache-Control', 'max-age=0')]
-        )
+        response = render_template('shopping-cart-esi.jinja', cart=cart)
+        response.headers['Cache-Control'] = 'max-age=0'
+        return response
 
     def _clear_cart(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ requires.append(
     )
 )
 # Explicitly add version of nereid which this module depends on
-requires.append('trytond_nereid>=3.0.4.0,<3.1')
+requires.append('trytond_nereid>=3.0.4.2,<3.1')
 
 setup(
     name='trytond_nereid_cart_b2c',

--- a/tests/test_cart.py
+++ b/tests/test_cart.py
@@ -402,6 +402,19 @@ class TestCart(BaseTestCase):
                     cart.sale.nereid_user, request.nereid_website.guest_user
                 )
 
+    def test_0110_cart_cache_header(self):
+        """
+        Ensure that the cart page has a no cache header
+        """
+        with Transaction().start(DB_NAME, USER, CONTEXT):
+            self.setup_defaults()
+            app = self.get_app()
+
+            with app.test_client() as c:
+                rv = c.get('/cart')
+                self.assertEqual(rv.status_code, 200)
+                self.assertEqual(rv.headers['Cache-Control'], 'max-age=0')
+
 
 def suite():
     "Cart test suite"


### PR DESCRIPTION
- It is required if downstream modules should be able to update the
  response context.
- Update dependency onf nereid 3.0.4.2 since the patch uses the
  capability in 3.0.4.2 to update headers in LazyRendered response
  objects
