### PR TITLE
Fix NoneType error when trying to update cart quantities

### DIFF
--- a/cart.py
+++ b/cart.py
@@ -359,7 +359,9 @@ class Cart(ModelSQL):
                 'product': product_id,
                 '_parent_sale.currency': sale.currency.id,
                 '_parent_sale.party': sale.party.id,
-                '_parent_sale.price_list': sale.price_list.id,
+                '_parent_sale.price_list': (
+                    sale.price_list.id if sale.price_list else None
+                ),
                 'unit': order_line.unit.id,
                 'quantity': quantity if action == 'set'
                     else quantity + order_line.quantity,


### PR DESCRIPTION
If sale has no price_list defined you can not change the quantity of a product. This PR fixes the problem. 
