### PR TITLE
Product image in cart status should be thumbnail

### DIFF
--- a/website.py
+++ b/website.py
@@ -188,7 +188,8 @@ class Website:
                     'unit': line.unit.symbol,
                     'unit_price': currency_format(line.unit_price),
                     'amount': currency_format(line.amount),
-                    'image': line.product.default_image.url,
+                    'image': line.product.image_sets[0].thumbnail.url
+                        if line.product.image_sets else None,
                 } for line in cart.sale.lines],
                 'empty': len(cart.sale.lines) > 0,
                 'total_amount': currency_format(cart.sale.total_amount),


### PR DESCRIPTION
Default size product image is not required in cart status. As cart
status is more focused on cart items and quantity in it.
