### PR TITLE
Currency format only when serialzation purpose is 'cart'

### DIFF
--- a/sale.py
+++ b/sale.py
@@ -152,14 +152,14 @@ class SaleLine:
         Serialize SaleLine data
         """
         res = {}
-        currency_format = partial(
-            numbers.format_currency, currency=self.sale.currency.code,
-            locale=request.nereid_language.code
-        )
-        number_format = partial(
-            numbers.format_number, locale=request.nereid_language.code
-        )
         if purpose == 'cart':
+            currency_format = partial(
+                numbers.format_currency, currency=self.sale.currency.code,
+                locale=request.nereid_language.code
+            )
+            number_format = partial(
+                numbers.format_number, locale=request.nereid_language.code
+            )
             res.update({
                 'id': self.id,
                 'display_name': (


### PR DESCRIPTION
As currency_format requires request context it should be set only when
serialization purpose is `cart`